### PR TITLE
fix(deps): bump pyo3 to clear RUSTSEC-2025-0020 + docs refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,23 @@ From the first tagged release onward, this file is maintained by
 - CI matrix across ubuntu/macos/windows with fmt + clippy + cargo-deny gates.
 - `dependabot`, `release-plz`, `cargo-deny`, and `CHANGELOG.md` infrastructure.
 - MSRV declared as 1.80 (earliest version supporting `std::sync::LazyLock`).
+- Go SQL extractor (`finder/go.rs`): raw / interpreted string literals
+  and `fmt.Sprintf`-style verbs.
+- JavaScript / TypeScript SQL extractor (`finder/javascript.rs`):
+  single-, double-, and template-string literals across `.js`, `.ts`,
+  and `.tsx`; `${…}` substitutions stripped before parsing.
+- `MERGE INTO … USING … ON … WHEN [NOT] MATCHED` validation
+  (`validation/clauses/merge.rs`).
+- Postgres-aware identifier folding (`schema::sql::fold_ident`):
+  unquoted identifiers fold to lower case, quoted identifiers preserve
+  case. Other dialects keep ASCII case-insensitive matching.
+- `sqlshield-introspect` crate: live schema reader for Postgres and
+  SQLite. Wired into the CLI as `--db-url` (and `db_url` in
+  `.sqlshield.toml`); mutually exclusive with `--schema`.
+- First-party VS Code extension under `editors/vscode/` wrapping
+  `sqlshield-lsp` over stdio.
+- LSP filetype coverage extended to `go`, `javascript`, `typescript`,
+  and `typescriptreact` alongside `python`, `rust`, and `sql`.
 
 ### Changed
 - `validate_files` now returns `Result` rather than panicking on schema load.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,10 +50,10 @@ Rough recipe:
 ## Architecture at a glance
 
 ```
-Source file (*.py, *.rs)
+Source file (*.py, *.rs, *.go, *.js, *.ts, *.tsx)
    │ tree-sitter extracts string literals
    ▼
-SQL string (with {…} placeholders replaced by `1`)
+SQL string (with {…} / ${…} / fmt verbs replaced by `1`)
    │ sqlparser parses
    ▼
 AST (Vec<Statement>)
@@ -66,6 +66,9 @@ Vec<SqlValidationError>
 - `sqlshield-cli` — thin clap-based CLI wrapper
 - `sqlshield-py` — PyO3 bindings exposing `validate_query` / `validate_files`
 - `sqlshield-lsp` — Language Server for editor integration
+- `sqlshield-introspect` — live schema reader for Postgres / SQLite,
+  consumed by the CLI's `--db-url` flag
+- `editors/vscode` — first-party VS Code extension wrapping `sqlshield-lsp`
 
 ## Releases
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -85,7 +85,7 @@ checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -96,7 +96,7 @@ checksum = "ffdcb70bdbc4d478427380519163274ac86e52916e10f0a8889adf0f96d3fee7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -204,7 +204,7 @@ dependencies = [
  "heck 0.4.1",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -326,7 +326,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -434,7 +434,7 @@ checksum = "e835b70203e41293343137df5c0664546da5745f82ec9b84d40be8336958447b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -671,12 +671,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "indoc"
-version = "1.0.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bfa799dd5ed20a7e349f3b4639aa80d74549c81716d9ec4f994c9b5815598306"
-
-[[package]]
 name = "itoa"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -797,15 +791,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "523dc4f511e55ab87b694dc30d0f820d60906ef06413f93d4d7a1385599cc149"
 
 [[package]]
-name = "memoffset"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
-dependencies = [
- "autocfg",
-]
-
-[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -845,9 +830,9 @@ dependencies = [
 
 [[package]]
 name = "once_cell"
-version = "1.19.0"
+version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fdb12b2476b595f9358c5161aa467c2438859caa136dec86c26fdd2efe17b92"
+checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
 
 [[package]]
 name = "parking_lot"
@@ -914,7 +899,7 @@ checksum = "d9b20ed30f105399776b9c883e68e536ef602a16ae6f596d2c473591d6ad64c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -928,6 +913,12 @@ name = "pkg-config"
 version = "0.3.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19f132c84eca552bf34cab8ec81f1c1dcc229b811638f9d283dceabe58c5569e"
+
+[[package]]
+name = "portable-atomic"
+version = "1.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
 
 [[package]]
 name = "postgres"
@@ -988,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1002,36 +993,32 @@ dependencies = [
 
 [[package]]
 name = "pyo3"
-version = "0.19.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e681a6cfdc4adcc93b4d3cf993749a4552018ee0a9b65fc0ccfad74352c72a38"
+checksum = "91fd8e38a3b50ed1167fb981cd6fd60147e091784c427b8f7183a7ee32c31c12"
 dependencies = [
- "cfg-if",
- "indoc",
  "libc",
- "memoffset",
- "parking_lot",
+ "once_cell",
+ "portable-atomic",
  "pyo3-build-config",
  "pyo3-ffi",
  "pyo3-macros",
- "unindent",
 ]
 
 [[package]]
 name = "pyo3-build-config"
-version = "0.19.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "076c73d0bc438f7a4ef6fdd0c3bb4732149136abd952b110ac93e4edb13a6ba5"
+checksum = "e368e7ddfdeb98c9bca7f8383be1648fd84ab466bf2bc015e94008db6d35611e"
 dependencies = [
- "once_cell",
  "target-lexicon",
 ]
 
 [[package]]
 name = "pyo3-ffi"
-version = "0.19.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e53cee42e77ebe256066ba8aa77eff722b3bb91f3419177cf4cd0f304d3284d9"
+checksum = "7f29e10af80b1f7ccaf7f69eace800a03ecd13e883acfacc1e5d0988605f651e"
 dependencies = [
  "libc",
  "pyo3-build-config",
@@ -1039,25 +1026,27 @@ dependencies = [
 
 [[package]]
 name = "pyo3-macros"
-version = "0.19.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dfeb4c99597e136528c6dd7d5e3de5434d1ceaf487436a3f03b2d56b6fc9efd1"
+checksum = "df6e520eff47c45997d2fc7dd8214b25dd1310918bbb2642156ef66a67f29813"
 dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
 name = "pyo3-macros-backend"
-version = "0.19.2"
+version = "0.28.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "947dc12175c254889edc0c02e399476c2f652b4b9ebd123aa655c224de259536"
+checksum = "c4cdc218d835738f81c2338f822078af45b4afdf8b2e33cbb5916f108b813acb"
 dependencies = [
+ "heck 0.5.0",
  "proc-macro2",
+ "pyo3-build-config",
  "quote",
- "syn 1.0.109",
+ "syn",
 ]
 
 [[package]]
@@ -1237,7 +1226,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1259,7 +1248,7 @@ checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1337,7 +1326,7 @@ checksum = "01b2e185515564f15375f593fb966b5718bc624ba77fe49fa4616ad619690554"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1432,17 +1421,6 @@ checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
 
 [[package]]
 name = "syn"
-version = "1.0.109"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72b64191b275b66ffe2469e8af2c1cfe3bafa67b529ead792a6d0160888b4237"
-dependencies = [
- "proc-macro2",
- "quote",
- "unicode-ident",
-]
-
-[[package]]
-name = "syn"
 version = "2.0.117"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e665b8803e7b1d2a727f4023456bbbbe74da67099c585258af0ad9c5013b9b99"
@@ -1460,14 +1438,14 @@ checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
 name = "target-lexicon"
-version = "0.12.13"
+version = "0.13.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69758bda2e78f098e4ccb393021a0963bb3442eac05f135c30f61b7370bbafae"
+checksum = "adb6935a6f5c20170eeceb1a3835a49e12e19d792f6dd344ccc76a985ca5a6ca"
 
 [[package]]
 name = "tempfile"
@@ -1498,7 +1476,7 @@ checksum = "c61f3ba182994efc43764a46c018c347bc492c79f024e705f46567b418f6d4f7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1558,7 +1536,7 @@ checksum = "385a6cb71ab9ab790c5fe8d67f1645e6c450a7ce006a33de03daa956cf70a496"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1685,7 +1663,7 @@ checksum = "84fd902d4e0b9a4b27f2f440108dc034e1758628a9b702f8ec61ad66355422fa"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1713,7 +1691,7 @@ checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -1855,12 +1833,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
-name = "unindent"
-version = "0.1.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e1766d682d402817b5ac4490b3c3002d91dfa0d22812f341609f97b08757359c"
-
-[[package]]
 name = "url"
 version = "2.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1987,7 +1959,7 @@ dependencies = [
  "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wasm-bindgen-shared",
 ]
 
@@ -2280,7 +2252,7 @@ dependencies = [
  "heck 0.5.0",
  "indexmap",
  "prettyplease",
- "syn 2.0.117",
+ "syn",
  "wasm-metadata",
  "wit-bindgen-core",
  "wit-component",
@@ -2296,7 +2268,7 @@ dependencies = [
  "prettyplease",
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "wit-bindgen-core",
  "wit-bindgen-rust",
 ]
@@ -2363,7 +2335,7 @@ checksum = "de844c262c8848816172cef550288e7dc6c7b7814b4ee56b3e1553f275f1858e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2384,7 +2356,7 @@ checksum = "70e3cd084b1788766f53af483dd21f93881ff30d7320490ec3ef7526d203bad4"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]
 
 [[package]]
@@ -2404,7 +2376,7 @@ checksum = "11532158c46691caf0f2593ea8358fed6bbf68a0315e80aae9bd41fbade684a1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
  "synstructure",
 ]
 
@@ -2438,5 +2410,5 @@ checksum = "625dc425cab0dca6dc3c3319506e6593dcb08a9f387ea3b284dbd52a92c40555"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.117",
+ "syn",
 ]

--- a/README.md
+++ b/README.md
@@ -28,6 +28,10 @@ It works on:
 - Plain `"…"` and raw `r#"…"#` Rust string literals (sqlx-idiomatic).
 - Python f-strings (`f"…{x}…"`) and `.format()` strings (`{{` / `}}`
   escapes preserved).
+- Go raw / interpreted string literals, including `fmt.Sprintf` verbs.
+- JavaScript / TypeScript single-, double-, and template-string literals
+  (`.js`, `.ts`, `.tsx`); `${…}` template substitutions are stripped
+  before parsing.
 - Standalone `.sql` files (via the LSP).
 
 It checks:
@@ -118,7 +122,15 @@ config; the config overrides defaults.
 schema = "db/schema.sql"
 directory = "src"
 dialect = "postgres"
+# Or pull the schema from a live database instead of a file:
+# db_url = "postgres://user:pass@localhost/mydb"
+# db_url = "sqlite:///abs/path/to/db.sqlite"
 ```
+
+Live introspection is feature-gated; the published binary ships with it
+on. To validate against a running database without a `.sql` file, pass
+`--db-url` (or set `db_url` in the config). Postgres and SQLite are
+supported today; MySQL is pending a Rust toolchain bump.
 
 Supported dialects: `generic` (default), `postgres` / `postgresql` / `pg`,
 `mysql`, `sqlite`, `mssql` / `sqlserver`, `snowflake`, `bigquery` / `bq`,
@@ -134,9 +146,13 @@ The walker prunes `target/`, `.git/`, `node_modules/`, `.venv/`, `venv/`,
 
 [`sqlshield-lsp`](sqlshield-lsp/README.md) is a Language Server that
 publishes diagnostics for embedded SQL on every `didOpen` / `didChange`.
-Any LSP-aware editor (VS Code, Neovim, Helix, Emacs, Zed) can show inline
+Any LSP-aware editor (Neovim, Helix, Emacs, Zed, …) can show inline
 squiggles on the offending SQL string. The crate's README has the wiring
 recipes.
+
+A first-party VS Code extension lives at
+[`editors/vscode/`](editors/vscode/README.md) — it spawns `sqlshield-lsp`
+over stdio and forwards diagnostics as you type.
 
 ## Python integration
 
@@ -176,9 +192,10 @@ errors = sqlshield.validate_query(
 | Function args / `CASE` / `CAST` / arithmetic         |   ✅   |
 | Case-insensitive identifier matching                 |   ✅   |
 | 12 SQL dialects via `--dialect`                      |   ✅   |
-| Live database introspection                          |   ✗    |
-| Quoted-vs-unquoted identifier folding (Postgres rules) |   ✗  |
-| `MERGE`                                              |   ✗    |
+| `MERGE INTO … USING … WHEN [NOT] MATCHED`            |   ✅   |
+| Postgres quoted-vs-unquoted identifier folding       |   ✅   |
+| Live database introspection (Postgres + SQLite)      |   ✅   |
+| MySQL live introspection                             |   ✗    |
 
 ## Limitations
 
@@ -219,6 +236,10 @@ Workspace layout:
 - [`sqlshield-cli/`](sqlshield-cli/) — clap-based CLI wrapper.
 - [`sqlshield-py/`](sqlshield-py/) — PyO3 bindings.
 - [`sqlshield-lsp/`](sqlshield-lsp/) — `tower-lsp` Language Server.
+- [`sqlshield-introspect/`](sqlshield-introspect/) — live schema reader
+  for Postgres and SQLite (consumed by `--db-url`).
+- [`editors/vscode/`](editors/vscode/) — first-party VS Code extension
+  wrapping `sqlshield-lsp`.
 
 ## Similar tools
 
@@ -233,9 +254,9 @@ Workspace layout:
   linter; complementary, not overlapping (squawk lints DDL, sqlshield
   lints embedded DML/SELECT).
 
-sqlshield's niche: language-agnostic extraction (Python + Rust today,
-extensible) with a multi-dialect parser, no database connection
-required.
+sqlshield's niche: language-agnostic extraction (Python, Rust, Go, and
+JavaScript / TypeScript today, extensible) with a multi-dialect parser,
+no database connection required (live introspection optional).
 
 ## Contributing
 

--- a/sqlshield-cli/README.md
+++ b/sqlshield-cli/README.md
@@ -1,8 +1,9 @@
 # sqlshield-cli
 
 Command-line linter for [sqlshield](https://github.com/davidsmfreire/sqlshield) —
-validates raw SQL strings embedded in Python and Rust source files
-against a declared schema, without touching a database.
+validates raw SQL strings embedded in Python, Rust, Go, and
+JavaScript / TypeScript source files against a declared schema (or a
+live Postgres / SQLite database).
 
 ## Install
 
@@ -23,7 +24,13 @@ sqlshield --directory src --schema schema.sql
 sqlshield [OPTIONS]
 
   -d, --directory <DIRECTORY>  Default: "."
-  -s, --schema    <SCHEMA>     Default: "schema.sql"
+  -s, --schema    <SCHEMA>     Default: "schema.sql".
+                               Mutually exclusive with --db-url.
+      --db-url    <URL>        Read schema from a live database instead
+                               of a file. Examples:
+                                 postgres://user:pass@localhost/mydb
+                                 sqlite:///abs/path/to/db.sqlite
+                                 ./relative.sqlite
       --dialect   <DIALECT>    generic | postgres | mysql | sqlite |
                                mssql | snowflake | bigquery | redshift |
                                clickhouse | duckdb | hive | ansi
@@ -46,6 +53,8 @@ for full details.
 schema = "db/schema.sql"
 directory = "src"
 dialect = "postgres"
+# Optional: introspect a running DB instead of reading schema.sql
+# db_url = "postgres://user:pass@localhost/mydb"
 ```
 
 ### Exit codes

--- a/sqlshield-lsp/README.md
+++ b/sqlshield-lsp/README.md
@@ -1,9 +1,10 @@
 # sqlshield-lsp
 
 Language Server Protocol frontend for [sqlshield](../README.md). Emits
-schema-aware SQL diagnostics for embedded queries in `.py` and `.rs` files as
-well as plain `.sql` files. Every editor that speaks LSP (VS Code, Neovim,
-Helix, Emacs, Zed, …) can show squiggles on the offending SQL string.
+schema-aware SQL diagnostics for embedded queries in `.py`, `.rs`, `.go`,
+`.js`, `.ts`, and `.tsx` files as well as plain `.sql` files. Every
+editor that speaks LSP (VS Code, Neovim, Helix, Emacs, Zed, …) can show
+squiggles on the offending SQL string.
 
 > **Status:** experimental — full-document sync, diagnostics only. No
 > completion, hover, or code actions yet.
@@ -42,7 +43,10 @@ if not configs.sqlshield_lsp then
   configs.sqlshield_lsp = {
     default_config = {
       cmd = { "sqlshield-lsp" },
-      filetypes = { "python", "rust", "sql" },
+      filetypes = {
+        "python", "rust", "go", "javascript",
+        "typescript", "typescriptreact", "sql",
+      },
       root_dir = require("lspconfig.util").root_pattern(".sqlshield.toml", ".git"),
       settings = {},
     },
@@ -53,8 +57,10 @@ require("lspconfig").sqlshield_lsp.setup({})
 
 ### VS Code
 
-Any generic LSP extension (for example, `llllvvuu.llmvm-lsp-client`) can
-launch `sqlshield-lsp`. A first-party VS Code extension is future work.
+A first-party VS Code extension lives at
+[`editors/vscode/`](../editors/vscode/README.md). It spawns
+`sqlshield-lsp` over stdio and forwards diagnostics to the editor as you
+type. Set `sqlshield.serverPath` if the binary isn't on `PATH`.
 
 ## Debugging
 

--- a/sqlshield-py/Cargo.toml
+++ b/sqlshield-py/Cargo.toml
@@ -19,5 +19,5 @@ crate-type = ["cdylib"]
 
 
 [dependencies]
-pyo3 = "0.19.0"
+pyo3 = "0.28"
 sqlshield = { workspace = true }

--- a/sqlshield-py/README.md
+++ b/sqlshield-py/README.md
@@ -37,10 +37,11 @@ for err in errors:
 # ./src/queries.py:7: Column `nickname` not found in table `users`
 ```
 
-`validate_files` walks `.py` and `.rs` source files, extracts every
-embedded SQL string, and validates each against the schema. Generated
-and vendored directories (`.git`, `target`, `node_modules`, `.venv`,
-`__pycache__`, …) are skipped automatically.
+`validate_files` walks `.py`, `.rs`, `.go`, `.js`, `.ts`, and `.tsx`
+source files, extracts every embedded SQL string, and validates each
+against the schema. Generated and vendored directories (`.git`,
+`target`, `node_modules`, `.venv`, `__pycache__`, …) are skipped
+automatically.
 
 Each `SqlValidationError` exposes:
 

--- a/sqlshield-py/src/lib.rs
+++ b/sqlshield-py/src/lib.rs
@@ -44,8 +44,8 @@ fn validate_query(query: &str, schema: &str) -> PyResult<Vec<String>> {
 
 /// A Python module implemented in Rust.
 #[pymodule]
-fn sqlshield(_py: Python, m: &PyModule) -> PyResult<()> {
-    m.add_class::<PySqlValidationError>().unwrap();
+fn sqlshield(m: &Bound<'_, PyModule>) -> PyResult<()> {
+    m.add_class::<PySqlValidationError>()?;
     m.add_function(wrap_pyfunction!(validate_files, m)?)?;
     m.add_function(wrap_pyfunction!(validate_query, m)?)?;
     Ok(())


### PR DESCRIPTION
## Summary
- Bump `sqlshield-py` to `pyo3 = "0.28"` to clear RUSTSEC-2025-0020 (buffer overflow in `PyString::from_object`, fixed in 0.24.1). Migrate the `#[pymodule]` entry point to the `Bound<'_, PyModule>` API introduced in pyo3 0.21.
- Refresh the user-facing docs to match what actually ships: Go and JS/TS extractors, `MERGE` validation, Postgres identifier folding, `sqlshield-introspect` (`--db-url`), the first-party VS Code extension, and the expanded LSP filetype list.

## Test plan
- [x] `cargo build --workspace --all-features`
- [x] `cargo test --workspace --all-features`
- [x] `cargo clippy --workspace --all-targets --all-features -- -D warnings`
- [ ] CI `audit` job clears (RUSTSEC-2025-0020 should be gone)
- [ ] CI `release-plz` job clears now that "Allow GitHub Actions to create and approve pull requests" is enabled

🤖 Generated with [Claude Code](https://claude.com/claude-code)